### PR TITLE
POC: Add multi-app

### DIFF
--- a/http.go
+++ b/http.go
@@ -11,7 +11,7 @@ import (
 
 type Server struct {
 	Handler http.Handler
-	Opts    *Options
+	Opts    *MultiAppProxyOptions
 }
 
 func (s *Server) ListenAndServe() {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/mreiferson/go-options"
@@ -16,11 +15,6 @@ func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flagSet := flag.NewFlagSet("oauth2_proxy", flag.ExitOnError)
 
-	emailDomains := StringArray{}
-	upstreams := StringArray{}
-	skipAuthRegex := StringArray{}
-	googleGroups := StringArray{}
-
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
 
@@ -28,58 +22,9 @@ func main() {
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
-	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
-	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
-	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
-	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
-	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
-	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
-	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
-	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
-	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
-	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
-	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
-	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
-
-	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
-	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
-	flagSet.String("github-org", "", "restrict logins to members of this organisation")
-	flagSet.String("github-team", "", "restrict logins to members of this team")
-	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")
-	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
-	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
-	flagSet.String("okta-domain", "", "the full domain for which your organization's okta is configured (example.okta.com)")
-	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
-	flagSet.String("client-secret", "", "the OAuth Client Secret")
-	flagSet.String("authenticated-emails-file", "", "authenticate against emails via file (one per line)")
-	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption or \"htpasswd -B\" for bcrypt encryption")
-	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
-	flagSet.String("custom-templates-dir", "", "path to custom html templates")
-	flagSet.String("footer", "", "custom footer string. Use \"-\" to disable default footer.")
-	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
-
-	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")
-	flagSet.String("cookie-secret", "", "the seed string for secure cookies (optionally base64 encoded)")
-	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
-	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
-	flagSet.Duration("cookie-refresh", time.Duration(0), "refresh the cookie after this duration; 0 to disable")
-	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
-	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
 	flagSet.Bool("request-logging", true, "Log requests to stdout")
 	flagSet.String("request-logging-format", defaultRequestLoggingFormat, "Template for log lines")
-
-	flagSet.String("provider", "google", "OAuth provider")
-	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
-	flagSet.String("login-url", "", "Authentication endpoint")
-	flagSet.String("redeem-url", "", "Token redemption endpoint")
-	flagSet.String("profile-url", "", "Profile access endpoint")
-	flagSet.String("resource", "", "The resource that is protected (Azure AD only)")
-	flagSet.String("validate-url", "", "Access token validation endpoint")
-	flagSet.String("scope", "", "OAuth scope specification")
-	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
-
-	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 
 	flagSet.Parse(os.Args[1:])
 
@@ -88,86 +33,22 @@ func main() {
 		return
 	}
 
-	globalOpts := NewOptions()
-
-	globalCfg := make(EnvOptions)
+	opts := NewMultiAppProxyOptions()
+	cfg := make(EnvOptions)
 	if *config != "" {
-		_, err := toml.DecodeFile(*config, &globalCfg)
+		_, err := toml.DecodeFile(*config, &cfg)
 		if err != nil {
 			log.Fatalf("ERROR: failed to load config file %s - %s", *config, err)
 		}
 	}
-	globalCfg.LoadEnvForStruct(globalOpts)
-	options.Resolve(globalOpts, flagSet, globalCfg)
+	cfg.LoadEnvForStruct(opts)
+	options.Resolve(opts, flagSet, cfg)
 
-	err := globalOpts.Validate()
-	if err != nil {
-		log.Printf("%s", err)
-		os.Exit(1)
-	}
-
-	// TODO: move to config
-	appCfgs := make(map[string]EnvOptions)
-
-	_, err = toml.Decode(`
-	["nirvine-app1.segment.com"]
-	skip_provider_button = true
-	set_xauthrequest = true
-	email_domains = [
-	"segment.com"
-	]
-	upstreams = [
-	"file://noop"
-	]
-	cookie_refresh = "5m"
-	provider = "okta"
-	okta_domain = "segment.oktapreview.com"
-	cookie_secret = "YXBwMXNlY3JldDAwMDAwMQ=="
-	# https://segment-admin.oktapreview.com/admin/app/oidc_client/instance/0oafor0pzyjZRBozQ0h7/#tab-general
-	client_id = "0oafor0pzyjZRBozQ0h7" # D
-	client_secret = "atNNFLhAtcVjkQ8LG88PHvLC68U6wYamQ6pO4Zmn"
-
-	# DEBUG Temp, must not be set for production
-	redirect_url = "https://nirvine-app1.segment.com:5000/oauth2/callback"
-
-	request_logging = true
-
-	["nirvine-app2.segment.com"]
-	skip_provider_button = true
-	set_xauthrequest = true
-	# http_address = "http://localhost:5000"
-	email_domains = [
-	"segment.com"
-	]
-	upstreams = [
-	"file://noop"
-	]
-	cookie_refresh = "5m"
-	provider = "okta"
-	okta_domain = "segment.oktapreview.com"
-	cookie_secret = "devsecretonly!!4"
-	# https://segment-admin.oktapreview.com/admin/app/oidc_client/client/0oafor4vn0Fea7wlH0h7#tab-general
-	client_id = "0oafor4ph0v3tod4j0h7" # D
-	client_secret = "doa64gMOiDeGjszhMF88XeJiJOiYJ7k5082RyfbK"
-
-	# DEBUG Temp, must not be set for production
-	redirect_url = "https://nirvine-app2.segment.com:5000/oauth2/callback"
-
-	request_logging = true
-	`, &appCfgs)
-	if err != nil {
-		log.Fatalf("ERROR: failed to load config: %s", err)
-	}
 	multiappproxy := MultiAppProxy{
 		AppToOAuthProxy: make(map[string]*OAuthProxy),
 	}
-	for domain, appCfg := range appCfgs {
-		appOpts := NewOptions()
-		appCfg.LoadEnvForStruct(appOpts)
-
-		options.Resolve(appOpts, flagSet, appCfg)
-
-		err = appOpts.Validate()
+	for domain, appOpts := range opts.Apps {
+		err := appOpts.Validate()
 		if err != nil {
 			log.Printf("%s", err)
 			os.Exit(1)
@@ -181,19 +62,9 @@ func main() {
 		multiappproxy.AppToOAuthProxy[domain] = oap
 	}
 
-	if len(globalOpts.EmailDomains) != 0 && globalOpts.AuthenticatedEmailsFile == "" {
-		// TODO
-		log.Printf("Warn: global EmailDomains/AuthenticatedEmailsFile is required but does nothing")
-	}
-
-	if globalOpts.HtpasswdFile != "" {
-		// TODO
-		log.Printf("Warn: global HtpasswdFile is required but does nothing")
-	}
-
 	s := &Server{
-		Handler: LoggingHandler(os.Stdout, multiappproxy, globalOpts.RequestLogging, globalOpts.RequestLoggingFormat),
-		Opts:    globalOpts,
+		Handler: LoggingHandler(os.Stdout, multiappproxy, opts.RequestLogging, opts.RequestLoggingFormat),
+		Opts:    opts,
 	}
 	s.ListenAndServe()
 }

--- a/multiappproxy.go
+++ b/multiappproxy.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+type MultiAppProxy struct {
+	// maps domain to an OAuthProxy
+	AppToOAuthProxy map[string]*OAuthProxy
+}
+
+func (m MultiAppProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// TODO: is r.Host the right thing to switch on?
+
+	k := r.Host
+
+	oap, ok := m.AppToOAuthProxy[k]
+	if !ok {
+		// TODO: is 404 the right way to handle this?
+		// nginx just masks this as 500 to the client
+		log.Printf("DEBUG: '%s' 404", k, oap)
+		//TODO is
+		http.Error(w, fmt.Sprintf("app for %s not found", k), 404)
+		return
+	}
+	// TODO: log better
+	log.Printf("DEBUG: '%s' routed to %v", k, oap)
+
+	oap.ServeHTTP(w, r)
+}

--- a/multiappproxy.go
+++ b/multiappproxy.go
@@ -6,6 +6,26 @@ import (
 	"net/http"
 )
 
+type MultiAppProxyOptions struct {
+	RequestLogging       bool                `flag:"request-logging" cfg:"request_logging"`
+	RequestLoggingFormat string              `flag:"request-logging-format" cfg:"request_logging_format"`
+	HttpAddress          string              `flag:"http-address" cfg:"http_address"`
+	HttpsAddress         string              `flag:"https-address" cfg:"https_address"`
+	TLSCertFile          string              `flag:"tls-cert" cfg:"tls_cert_file"`
+	TLSKeyFile           string              `flag:"tls-key" cfg:"tls_key_file"`
+	Apps                 map[string]*Options `cfg:apps`
+}
+
+func NewMultiAppProxyOptions() *MultiAppProxyOptions {
+	return &MultiAppProxyOptions{
+		HttpAddress:          "127.0.0.1:4180",
+		HttpsAddress:         ":443",
+		RequestLogging:       true,
+		RequestLoggingFormat: defaultRequestLoggingFormat,
+		Apps:                 make(map[string]*Options),
+	}
+}
+
 type MultiAppProxy struct {
 	// maps domain to an OAuthProxy
 	AppToOAuthProxy map[string]*OAuthProxy

--- a/options.go
+++ b/options.go
@@ -20,6 +20,7 @@ import (
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
+	// TODO remove all flags
 	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
 	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID     string `flag:"client-id" cfg:"client_id"`
@@ -90,8 +91,6 @@ type SignatureData struct {
 func NewOptions() *Options {
 	return &Options{
 		ProxyPrefix:         "/oauth2",
-		HttpAddress:         "127.0.0.1:4180",
-		HttpsAddress:        ":443",
 		DisplayHtpasswdForm: true,
 		CookieName:          "_oauth2_proxy",
 		CookieSecure:        true,

--- a/options.go
+++ b/options.go
@@ -21,13 +21,9 @@ import (
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
 	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
-	HttpAddress  string `flag:"http-address" cfg:"http_address"`
-	HttpsAddress string `flag:"https-address" cfg:"https_address"`
 	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
-	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
-	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
-	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
-	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
+	ClientID     string `flag:"client-id" cfg:"client_id"`
+	ClientSecret string `flag:"client-secret" cfg:"client_secret"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
@@ -43,11 +39,11 @@ type Options struct {
 	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 	Footer                   string   `flag:"footer" cfg:"footer"`
 
-	CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
-	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
-	CookieDomain   string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
-	CookieExpire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
-	CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
+	CookieName     string        `flag:"cookie-name" cfg:"cookie_name"`
+	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret"`
+	CookieDomain   string        `flag:"cookie-domain" cfg:"cookie_domain"`
+	CookieExpire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire"`
+	CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh"`
 	CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	CookieHttpOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 
@@ -75,10 +71,7 @@ type Options struct {
 	Scope             string `flag:"scope" cfg:"scope"`
 	ApprovalPrompt    string `flag:"approval-prompt" cfg:"approval_prompt"`
 
-	RequestLogging       bool   `flag:"request-logging" cfg:"request_logging"`
-	RequestLoggingFormat string `flag:"request-logging-format" cfg:"request_logging_format"`
-
-	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
+	SignatureKey string `flag:"signature-key" cfg:"signature_key"`
 
 	// internal values that are set after config validation
 	redirectURL   *url.URL
@@ -96,24 +89,22 @@ type SignatureData struct {
 
 func NewOptions() *Options {
 	return &Options{
-		ProxyPrefix:          "/oauth2",
-		HttpAddress:          "127.0.0.1:4180",
-		HttpsAddress:         ":443",
-		DisplayHtpasswdForm:  true,
-		CookieName:           "_oauth2_proxy",
-		CookieSecure:         true,
-		CookieHttpOnly:       true,
-		CookieExpire:         time.Duration(168) * time.Hour,
-		CookieRefresh:        time.Duration(0),
-		SetXAuthRequest:      false,
-		SkipAuthPreflight:    false,
-		PassBasicAuth:        true,
-		PassUserHeaders:      true,
-		PassAccessToken:      false,
-		PassHostHeader:       true,
-		ApprovalPrompt:       "force",
-		RequestLogging:       true,
-		RequestLoggingFormat: defaultRequestLoggingFormat,
+		ProxyPrefix:         "/oauth2",
+		HttpAddress:         "127.0.0.1:4180",
+		HttpsAddress:        ":443",
+		DisplayHtpasswdForm: true,
+		CookieName:          "_oauth2_proxy",
+		CookieSecure:        true,
+		CookieHttpOnly:      true,
+		CookieExpire:        time.Duration(168) * time.Hour,
+		CookieRefresh:       time.Duration(0),
+		SetXAuthRequest:     false,
+		SkipAuthPreflight:   false,
+		PassBasicAuth:       true,
+		PassUserHeaders:     true,
+		PassAccessToken:     false,
+		PassHostHeader:      true,
+		ApprovalPrompt:      "force",
 	}
 }
 


### PR DESCRIPTION
(Sneak preview.)

Splits oauth flows based on `Host` to separate OAuth clients. This would require a true fork, as the config/env/flags are not compatible.

New config looks like:

```
request_logging = true

[apps."nirvine-app1.segment.com"]
skip_provider_button = true
set_xauthrequest = true
email_domains = [
  "segment.com"
]
upstreams = [
  "file://noop"
]
cookie_refresh = "5m"
provider = "okta"
okta_domain = "segment.oktapreview.com"
cookie_secret = "..."
client_id = "0oafor0pzyjZRBozQ0h7" # D
client_secret = "..."

redirect_url = "https://nirvine-app1.segment.com:5000/oauth2/callback"


[apps."nirvine-app2.segment.com"]
skip_provider_button = true
set_xauthrequest = true
email_domains = [
  "segment.com"
]
upstreams = [
  "file://noop"
]
cookie_refresh = "5m"
provider = "okta"
okta_domain = "segment.oktapreview.com"
cookie_secret = "..."
client_id = "0oafor4ph0v3tod4j0h7" # D
client_secret = "..."

redirect_url = "https://nirvine-app2.segment.com:5000/oauth2/callback"
```